### PR TITLE
add opt_slice for converting an &Option<A> into slice

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,10 +12,30 @@ pub fn mut_ref_slice<A>(s: &mut A) -> &mut [A] {
     }
 }
 
+/// Converts a reference to Option<A> into a slice of length 0 or 1 (without copying).
+pub fn opt_slice<A>(opt: &Option<A>) -> &[A]
+{
+    match *opt {
+        Some(ref val) => ref_slice(val),
+        None => &[],
+    }
+}
+
+/// Converts a reference to Option<A> into a slice of length 0 or 1 (without copying).
+pub fn mut_opt_slice<A>(opt: &mut Option<A>) -> &mut [A]
+{
+    match *opt {
+        Some(ref mut val) => mut_ref_slice(val),
+        None => &mut [],
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::ref_slice;
     use super::mut_ref_slice;
+    use super::opt_slice;
+    use super::mut_opt_slice;
 
     #[test]
     fn check() {
@@ -35,5 +55,33 @@ mod tests {
         let result: &mut [i32] = &mut [5];
 
         assert_eq!(result, xs);
+    }
+
+    #[test]
+    fn check_opt() {
+        let x = &Some(42);
+        let n = &None;
+        let xs = opt_slice(x);
+        let ns = opt_slice(n);
+
+        let result_x: &[i32] = &[42];
+        let result_n: &[i32] = &[];
+
+        assert_eq!(result_x, xs);
+        assert_eq!(result_n, ns);
+    }
+
+    #[test]
+    fn check_opt_mut() {
+        let x = &mut Some(42);
+        let n = &mut None;
+        let xs = mut_opt_slice(x);
+        let ns = mut_opt_slice(n);
+
+        let result_x: &[i32] = &mut [42];
+        let result_n: &[i32] = &mut [];
+
+        assert_eq!(result_x, xs);
+        assert_eq!(result_n, ns);
     }
 }


### PR DESCRIPTION
Since `Option.as_slice` is marked as deprecated, it would be a good idea to add this here too.
