### PR TITLE
use the same _mut naming convention as std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+pub use self::ref_slice_mut as mut_ref_slice;
+pub use self::opt_slice_mut as mut_opt_slice;
+
 /// Converts a reference to A into a slice of length 1 (without copying).
 pub fn ref_slice<A>(s: &A) -> &[A] {
     unsafe {
@@ -6,7 +9,7 @@ pub fn ref_slice<A>(s: &A) -> &[A] {
 }
 
 /// Converts a reference to A into a slice of length 1 (without copying).
-pub fn mut_ref_slice<A>(s: &mut A) -> &mut [A] {
+pub fn ref_slice_mut<A>(s: &mut A) -> &mut [A] {
     unsafe {
         std::slice::from_raw_parts_mut(s, 1)
     }
@@ -22,7 +25,7 @@ pub fn opt_slice<A>(opt: &Option<A>) -> &[A]
 }
 
 /// Converts a reference to Option<A> into a slice of length 0 or 1 (without copying).
-pub fn mut_opt_slice<A>(opt: &mut Option<A>) -> &mut [A]
+pub fn opt_slice_mut<A>(opt: &mut Option<A>) -> &mut [A]
 {
     match *opt {
         Some(ref mut val) => mut_ref_slice(val),


### PR DESCRIPTION
This retains compatibility by re-exporting with the old names.
The tests are unchanged, as a proof of backwards compatibility.
