### PR TITLE
Add `#[inline]` annotations.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub use self::ref_slice_mut as mut_ref_slice;
 pub use self::opt_slice_mut as mut_opt_slice;
 
 /// Converts a reference to `A` into a slice of length 1 (without copying).
+#[inline]
 pub fn ref_slice<A>(s: &A) -> &[A] {
     unsafe {
         core::slice::from_raw_parts(s, 1)
@@ -11,6 +12,7 @@ pub fn ref_slice<A>(s: &A) -> &[A] {
 }
 
 /// Converts a reference to `A` into a slice of length 1 (without copying).
+#[inline]
 pub fn ref_slice_mut<A>(s: &mut A) -> &mut [A] {
     unsafe {
         core::slice::from_raw_parts_mut(s, 1)
@@ -18,6 +20,7 @@ pub fn ref_slice_mut<A>(s: &mut A) -> &mut [A] {
 }
 
 /// Converts a reference to `Option<A>` into a slice of length 0 or 1 (without copying).
+#[inline]
 pub fn opt_slice<A>(opt: &Option<A>) -> &[A]
 {
     match *opt {
@@ -27,6 +30,7 @@ pub fn opt_slice<A>(opt: &Option<A>) -> &[A]
 }
 
 /// Converts a reference to `Option<A>` into a slice of length 0 or 1 (without copying).
+#[inline]
 pub fn opt_slice_mut<A>(opt: &mut Option<A>) -> &mut [A]
 {
     match *opt {


### PR DESCRIPTION
`ref_slice` and friends are all very simple functions that will often be
beneficial to inline into their callers within other crates.