### PR TITLE
deprecate ref_slice and ref_slice_mut in favour of std methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,29 +1,30 @@
 #![no_std]
 
-pub use self::ref_slice_mut as mut_ref_slice;
 pub use self::opt_slice_mut as mut_opt_slice;
+#[allow(deprecated)]
+pub use self::ref_slice_mut as mut_ref_slice;
 
 /// Converts a reference to `A` into a slice of length 1 (without copying).
 #[inline]
+#[deprecated = "Similar method was added to std and stabilized in rust 1.28.0. \
+                Use `core::slice::from_ref` instead."]
 pub fn ref_slice<A>(s: &A) -> &[A] {
-    unsafe {
-        core::slice::from_raw_parts(s, 1)
-    }
+    unsafe { core::slice::from_raw_parts(s, 1) }
 }
 
 /// Converts a reference to `A` into a slice of length 1 (without copying).
 #[inline]
+#[deprecated = "Similar method was added to std and stabilized in rust 1.28.0. \
+                Use `core::slice::from_mut` instead."]
 pub fn ref_slice_mut<A>(s: &mut A) -> &mut [A] {
-    unsafe {
-        core::slice::from_raw_parts_mut(s, 1)
-    }
+    unsafe { core::slice::from_raw_parts_mut(s, 1) }
 }
 
 /// Converts a reference to `Option<A>` into a slice of length 0 or 1 (without copying).
 #[inline]
-pub fn opt_slice<A>(opt: &Option<A>) -> &[A]
-{
+pub fn opt_slice<A>(opt: &Option<A>) -> &[A] {
     match *opt {
+        #[allow(deprecated)]
         Some(ref val) => ref_slice(val),
         None => &[],
     }
@@ -31,9 +32,9 @@ pub fn opt_slice<A>(opt: &Option<A>) -> &[A]
 
 /// Converts a reference to `Option<A>` into a slice of length 0 or 1 (without copying).
 #[inline]
-pub fn opt_slice_mut<A>(opt: &mut Option<A>) -> &mut [A]
-{
+pub fn opt_slice_mut<A>(opt: &mut Option<A>) -> &mut [A] {
     match *opt {
+        #[allow(deprecated)]
         Some(ref mut val) => mut_ref_slice(val),
         None => &mut [],
     }
@@ -41,10 +42,12 @@ pub fn opt_slice_mut<A>(opt: &mut Option<A>) -> &mut [A]
 
 #[cfg(test)]
 mod tests {
-    use super::ref_slice;
+    #![allow(deprecated)]
+
+    use super::mut_opt_slice;
     use super::mut_ref_slice;
     use super::opt_slice;
-    use super::mut_opt_slice;
+    use super::ref_slice;
 
     #[test]
     fn check() {


### PR DESCRIPTION
Since similar methods were entroduced to `std` a while ago I've figured out it may be a good idea to deprecate them here. 
